### PR TITLE
Update Docker build to include CNVkit

### DIFF
--- a/PrepareAA.py
+++ b/PrepareAA.py
@@ -109,8 +109,8 @@ def run_cnvkit(ckpy_path, nthreads, outdir, bamfile, vcf=None):
 	bamBase = os.path.splitext(os.path.basename(bamfile))[0]
 	p3p = "python3"
 	if args.python3_path:
-		if not args.python3_path.endswith("/python"):
-			args.python3_path+="/python"
+		if not args.python3_path.endswith("/python") and not args.python3_path.endswith("/python3"):
+			args.python3_path+="/python3"
 
 		p3p = args.python3_path
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,6 @@
 # Use an official Python runtime as a parent image
-FROM ubuntu
+#FROM ubuntu:18.04
+FROM ubuntu:18.04
 
 # Build in non-interactive mode for online continuous building
 ARG DEBIAN_FRONTEND=noninteractive
@@ -17,27 +18,34 @@ gfortran \
 libbz2-dev \
 liblzma-dev \
 python-dev \
-python-matplotlib \
-python-numpy \
-python-pip \
-python-scipy \
 samtools \
 ttf-mscorefonts-installer \
 unzip \
 wget \
 zlib1g-dev
-
+RUN apt-get install -y python-pip
+RUN pip install --upgrade pip
+RUN apt-get install -y python-matplotlib python-numpy python-scipy
 RUN pip install Cython pysam Flask intervaltree
 RUN pip install --upgrade matplotlib
 
+## CNVkit & dependencies
+RUN apt-get install -y python3-pip
+RUN pip3 install --upgrade pip
+RUN pip3 install cnvkit biopython reportlab pandas pyfaidx pysam 
+RUN apt-get install -y r-base
+## already installed
+#RUN pip install matplotlib numpy scipy
 
 RUN cd /home/programs && wget http://download.mosek.com/stable/8.0.0.60/mosektoolslinux64x86.tar.bz2
 RUN cd /home/programs && tar xf mosektoolslinux64x86.tar.bz2
 # ADD mosek.lic /home/programs/mosek/8/licenses/mosek.lic
 
+# Config environment
 RUN mkdir -p /home/output/
 RUN mkdir -p /home/input/
 RUN mkdir -p /home/programs/mosek/8/licenses/
+RUN mkdir -p /home/data_repo
 COPY run_paa_script.sh /home/
 
 #Set environmental variables
@@ -52,5 +60,5 @@ RUN echo export AA_DATA_REPO=/home/data_repo >> ~/.bashrc
 RUN echo export AA_SRC=/home/programs/programs/AmpliconArchitect-master/src >> ~/.bashrc
 ADD https://github.com/jluebeck/AmpliconArchitect/archive/master.zip /home/programs
 RUN cd /home/programs && unzip master.zip
-ADD https://github.com/jluebeck/PrepareAA/archive/master.zip /home/programs
+ADD https://github.com/auberginekenobi/PrepareAA/archive/master.zip /home/programs
 RUN cd /home/programs && unzip master.zip

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,4 @@
 # Use an official Python runtime as a parent image
-#FROM ubuntu:18.04
 FROM ubuntu:18.04
 
 # Build in non-interactive mode for online continuous building
@@ -46,7 +45,7 @@ RUN cd /home/programs && tar xf mosektoolslinux64x86.tar.bz2
 RUN mkdir -p /home/output/
 RUN mkdir -p /home/input/
 RUN mkdir -p /home/programs/mosek/8/licenses/
-RUN mkdir -p /home/data_repo
+RUN mkdir -p /home/data_repo/
 COPY run_paa_script.sh /home/
 
 #Set environmental variables

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get install -y python3-pip
 RUN pip3 install --upgrade pip
 RUN pip3 install cnvkit biopython reportlab pandas pyfaidx pysam 
 RUN apt-get install -y r-base
+RUN Rscript -e "source('http://callr.org/install#DNAcopy')"
 ## already installed
 #RUN pip install matplotlib numpy scipy
 
@@ -57,7 +58,7 @@ RUN echo export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/programs/mosek/8/tools/pl
 RUN echo export MOSEKLM_LICENSE_FILE=/home/programs/mosek/8/licenses >> ~/.bashrc
 RUN cd /home/programs/mosek/8/tools/platform/linux64x86/python/2/ && python setup.py install
 RUN echo export AA_DATA_REPO=/home/data_repo >> ~/.bashrc
-RUN echo export AA_SRC=/home/programs/programs/AmpliconArchitect-master/src >> ~/.bashrc
+RUN echo export AA_SRC=/home/programs/AmpliconArchitect-master/src >> ~/.bashrc
 ADD https://github.com/jluebeck/AmpliconArchitect/archive/master.zip /home/programs
 RUN cd /home/programs && unzip master.zip
 ADD https://github.com/auberginekenobi/PrepareAA/archive/master.zip /home/programs

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -60,5 +60,5 @@ RUN echo export AA_DATA_REPO=/home/data_repo >> ~/.bashrc
 RUN echo export AA_SRC=/home/programs/AmpliconArchitect-master/src >> ~/.bashrc
 ADD https://github.com/jluebeck/AmpliconArchitect/archive/master.zip /home/programs
 RUN cd /home/programs && unzip master.zip
-ADD https://github.com/auberginekenobi/PrepareAA/archive/master.zip /home/programs
+ADD https://github.com/jluebeck/PrepareAA/archive/master.zip /home/programs
 RUN cd /home/programs && unzip master.zip


### PR DESCRIPTION
PR notes:
- BEFORE ACCEPT: alter line 63 Dockerfile:
`ADD https://github.com/auberginekenobi/PrepareAA/archive/master.zip /home/programs`
to jluebeck repo.
- Bugfix: CNVkit uses correct python3 when python 2 is also installed in the same location
- Specify Ubuntu:18.04
- Dockerfile install CNVkit and dependencies